### PR TITLE
Remove items triggering security issues due to clear text logging

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -3,9 +3,12 @@ targetScope = 'subscription'
 param region string
 param rgName string
 param vnetConfig object
+@secure()
 param cyclecloudConfig object
+@secure()
 param prometheusConfig object
 param anfConfig object
+@secure()
 param MySqlConfig object
 param roleDefinitionIds object
 param deployingUserObjId string
@@ -142,7 +145,6 @@ output globalVars object = {
   cycleserverName: CycleCloud.outputs.name
   cycleserverId: CycleCloud.outputs.id
   cycleserverAdmin: CycleCloud.outputs.adminUser
-  cycleserverAdminPubKey: CycleCloud.outputs.adminPublicKey
   clusterSubnetName: 'compute'
   keyVaultName: KeyVault.outputs.name
   lockerAccountName: CycleCloud.outputs.lockerSAName
@@ -154,7 +156,6 @@ output globalVars object = {
   vnetName: clusterNetwork.outputs.vnetName
   mySqlFqdn: MySql.outputs.fqdn
   mySqlUser: MySql.outputs.user
-  mySqlPwd: MySqlConfig.dbAdminPwd
   loginNicsCount: loginNIC.outputs.count
   loginNicsId: loginNIC.outputs.ids
   loginNicsPublicIP: loginNIC.outputs.public_ips

--- a/bicep/modules/anf.bicep
+++ b/bicep/modules/anf.bicep
@@ -1,6 +1,7 @@
 param region string
 param subnetIds object
 param allowedIpRange string
+@secure()
 param config object
 
 var anfAccountName = substring('${config.accountName}-${uniqueString(resourceGroup().id)}', 0, 16)

--- a/bicep/modules/cyclecloud.bicep
+++ b/bicep/modules/cyclecloud.bicep
@@ -1,4 +1,5 @@
 param region string
+@secure()
 param config object
 param subnetIds object
 param kvName string
@@ -213,7 +214,5 @@ resource lockerContainer 'Microsoft.Storage/storageAccounts/blobServices/contain
 output name string = cycleserver.name
 output id string = cycleserver.id
 output adminUser string = cycleserver.properties.osProfile.adminUsername
-output adminPublicKey string = config.sshPublicKey
 output privateIp string = cycleserverNIC.properties.ipConfigurations[0].properties.privateIPAddress
 output lockerSAName string = lockerAccount.name
-

--- a/bicep/modules/mysql.bicep
+++ b/bicep/modules/mysql.bicep
@@ -1,4 +1,5 @@
 param region string
+@secure()
 param config object
 param kvName string
 param subnetId string

--- a/bicep/modules/prometheus_scraper.bicep
+++ b/bicep/modules/prometheus_scraper.bicep
@@ -1,4 +1,5 @@
 param region string
+@secure()
 param config object
 param subnetIds object
 

--- a/bicep/modules/telemetry.bicep
+++ b/bicep/modules/telemetry.bicep
@@ -2,6 +2,7 @@ targetScope = 'subscription'
 
 param region string
 param rgName string
+@secure()
 param config object
 param principalObjId string
 param roleDefinitionIds object

--- a/install.sh
+++ b/install.sh
@@ -163,6 +163,10 @@ if [ ${RUN_BICEP} == true ]; then
     jq --arg hpcSku "${HPC_SKU}" '.globalVars.value.hpcSku = $hpcSku' ${DEPLOYMENT_OUTPUT} > temp.json && mv temp.json ${DEPLOYMENT_OUTPUT}
     jq --arg hpcMaxCoreCount "${HPC_MAX_CORE_COUNT}" '.globalVars.value.hpcMaxCoreCount = $hpcMaxCoreCount' ${DEPLOYMENT_OUTPUT} > temp.json && mv temp.json ${DEPLOYMENT_OUTPUT}
     jq --arg hpcMaxNumVMs "${HPC_MAX_NUM_VMS}" '.globalVars.value.hpcMaxNumVMs = $hpcMaxNumVMs' ${DEPLOYMENT_OUTPUT} > temp.json && mv temp.json ${DEPLOYMENT_OUTPUT}
+
+    # Add fields removed from deployment output to be ingested by Ansible
+    jq --arg cycleserverAdminPubKey "$(cat cycleadmin_id_rsa.pub)" '.globalVars.value.cycleserverAdminPubKey = $cycleserverAdminPubKey' ${DEPLOYMENT_OUTPUT} > temp.json && mv temp.json ${DEPLOYMENT_OUTPUT}
+    jq --arg mySqlPwd "$(cat mysql_admin_pwd.txt)" '.globalVars.value.mySqlPwd = $mySqlPwd' ${DEPLOYMENT_OUTPUT} > temp.json && mv temp.json ${DEPLOYMENT_OUTPUT}
     rm -f ${ROLE_ASSIGNMENT_OUTPUT_FILE}
 fi
 


### PR DESCRIPTION
Mark config objects that hold secrets as secure to avoid logging during deployment.

Propagate variables to Ansible using local sources instead of capturing from Bicep output as those need to be removed.