### PR TITLE
fix typo in run_nhc.sh

### DIFF
--- a/ansible/playbooks/roles/cyclecloud_cluster/files/cc_projects/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
+++ b/ansible/playbooks/roles/cyclecloud_cluster/files/cc_projects/cc_slurm_nhc/specs/default/cluster-init/files/run_nhc.sh
@@ -36,7 +36,7 @@ exclusive_node_rc=$?
 set_detached_mode 0
 NHC_RC=0
 if [ $exclusive_node_rc -eq 0 ]; then
-   echo "[$prolog_eplilog] execute nhc" >> /var/log/nhc.log
+   echo "[$prolog_epilog] execute nhc" >> /var/log/nhc.log
    sudo /usr/sbin/nhc
    NHC_RC=$?
 fi


### PR DESCRIPTION
fix small typo in run_nhc.sh that may actually prevent nhc from running (if executed with `set -e` enabled)